### PR TITLE
Fix concurrency race conditions by using persistent_term instead of ets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ defp deps do
 end
 ```
 
-### Why we need another UUID library? 
+Required at least OTP 21.3
+
+### Why we need another UUID library?
 
 I am of the idea that we need a UUID set of tools for our Elixir projects that is fast and complete (that is the reason for the name).
-Even if now the library does not seem different than UUID or other erlang versions of it, the direction is to create a swiss knife of unique id generation 
+Even if now the library does not seem different than UUID or other erlang versions of it, the direction is to create a swiss knife of unique id generation
 in our Elixir projects that is fast, complete and relaiable.
 
 


### PR DESCRIPTION
Additionally, if needed to make it working with ets for older releases, we need to add supervision tree and worker, which holds ets and creates this entry by starting of the application.